### PR TITLE
Update workflow to use self-hosted runners

### DIFF
--- a/.github/workflows/post-release-docker-hub.yml
+++ b/.github/workflows/post-release-docker-hub.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-and-release:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
We have optimized GitHub Runners to enhance resource utilization and efficiency by reducing the default packages loaded by runners. Introducing new runner groups for better customization and performance

---
### Note: New runners are deployed as minimal environments without pre-installed software like .NET. You'll need to install any required dependencies within your workflow.

For example: Following code snippet installs dotnet v3.1. For more information visit https://github.com/actions/setup-dotnet
```
    steps:
    - uses: actions/checkout@v4
    - uses: actions/setup-dotnet@v4
    with:
        dotnet-version: '3.1.x'
    - run: dotnet build <my project>
```

For more information checkout https://betssongroup.atlassian.net/wiki/spaces/TTM/pages/428605820/Transition+repositories+to+new+dedicated+runner+group

New runners include labels for example:
- `self-hosted` `X64` `Linux` `d-s` `default-standard`
- `self-hosted` `X64` `Linux` `d-l` `default-large`
>Builds should be compatible with both `x86-64` and `ARM64` architectures. If necessary, you can specify the architecture in the workflow

The assignment of runners depends not only on these labels but also based on the repository's association with specific runner groups and corresponding github apps managed by the CloudOps team.